### PR TITLE
友盟SDK迁移更新

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -4,7 +4,7 @@ buildscript {
         maven { url 'http://maven.aliyun.com/nexus/content/groups/public/' }
         maven { url 'http://oss.sonatype.org/content/repositories/snapshots' }
         maven { url "https://jitpack.io" }
-        maven { url 'https://dl.bintray.com/umsdk/release' }
+        maven { url 'https://repo1.maven.org/maven2/' }
         mavenCentral()
         google()
         jcenter()
@@ -21,7 +21,7 @@ allprojects {
         google()
         jcenter()
         maven { url "https://jitpack.io" }
-        maven { url 'https://dl.bintray.com/umsdk/release' }
+        maven { url 'https://repo1.maven.org/maven2/' }
         flatDir {
             dirs 'libs'
         }

--- a/lib_cloud/build.gradle
+++ b/lib_cloud/build.gradle
@@ -33,7 +33,7 @@ dependencies {
 
     implementation 'com.tencent.bugly:crashreport:3.1.9'
 
-    implementation 'com.umeng.umsdk:analytics:8.1.6'
-    implementation 'com.umeng.umsdk:common:2.2.5'
+    implementation 'com.umeng.umsdk:asms:1.2.2'
+    implementation 'com.umeng.umsdk:common:9.3.8'
 
 }


### PR DESCRIPTION
https://info.umeng.com/detail?id=443&cateId=1

由于 bintray.com(jcenter) 业务调整，友盟+于2021年5月6日将各业务线的最新版SDK迁移至maven center。您在后续使用自动集成或升级时，需要做如下修改：