### PR TITLE
把默认的导航条颜色修改为透明，更好得与各种主题颜色适配；

### DIFF
--- a/nga_phone_base_3.0/src/main/java/gov/anzong/androidnga/activity/BaseActivity.java
+++ b/nga_phone_base_3.0/src/main/java/gov/anzong/androidnga/activity/BaseActivity.java
@@ -3,6 +3,7 @@ package gov.anzong.androidnga.activity;
 import android.content.ActivityNotFoundException;
 import android.content.Context;
 import android.content.Intent;
+import android.graphics.Color;
 import android.os.Bundle;
 import android.view.KeyEvent;
 import android.view.MenuItem;
@@ -54,6 +55,9 @@ public abstract class BaseActivity extends AppCompatActivity {
         if (mSwipeBackHelper != null) {
             mSwipeBackHelper.onCreate(this);
         }
+
+        // Set Transparent as the default color to match the theme
+        getWindow().setNavigationBarColor(Color.TRANSPARENT);
 
         try {
             if (ThemeManager.getInstance().isNightMode()) {


### PR DESCRIPTION
当前的版本，导航条是单纯的白色，和主窗口的颜色不匹配，影响观感。
解决方式是，把透明色设置为默认的颜色。
