### PR TITLE
修复点击搜索按钮时 crash 问题

### DIFF
--- a/nga_phone_base_3.0/src/main/java/gov/anzong/androidnga/activity/SearchActivity.java
+++ b/nga_phone_base_3.0/src/main/java/gov/anzong/androidnga/activity/SearchActivity.java
@@ -1,5 +1,6 @@
 package gov.anzong.androidnga.activity;
 
+import android.os.Build;
 import android.os.Bundle;
 import androidx.fragment.app.FragmentTabHost;
 import androidx.appcompat.app.ActionBar;
@@ -89,7 +90,9 @@ public class SearchActivity extends BaseActivity {
         SearchView searchView = (SearchView) item.getActionView();
         mEditText = searchView.findViewById(androidx.appcompat.R.id.search_src_text);
         mEditText.setCursorVisible(true);
-        mEditText.setTextCursorDrawable(R.drawable.text_cursor_drawable);
+        if (Build.VERSION.SDK_INT >= 29) {
+            mEditText.setTextCursorDrawable(R.drawable.text_cursor_drawable);
+        }
         mEditText.setOnEditorActionListener((v, actionId, event) -> {
             query(v.getText());
             return true;


### PR DESCRIPTION
`mEditText.setTextCursorDrawable` 是 api 29 引入的, 会 crash. 先加个判断