### PR TITLE
修复并优化内置浏览器逻辑

### DIFF
--- a/nga_phone_base_3.0/src/main/java/gov/anzong/androidnga/activity/fragment/WebViewFragment.java
+++ b/nga_phone_base_3.0/src/main/java/gov/anzong/androidnga/activity/fragment/WebViewFragment.java
@@ -22,6 +22,8 @@ import android.webkit.WebViewClient;
 import androidx.annotation.NonNull;
 import androidx.annotation.Nullable;
 
+import com.google.common.base.Strings;
+
 import gov.anzong.androidnga.R;
 import gov.anzong.androidnga.base.util.PreferenceUtils;
 import gov.anzong.androidnga.common.PreferenceKey;
@@ -85,10 +87,11 @@ public class WebViewFragment extends BaseFragment {
 
             @Override
             public boolean shouldOverrideUrlLoading(WebView view, WebResourceRequest request) {
-                if (!request.getUrl().toString().contains("nga") || request.getUrl().toString().contains("178")) {
-                    startExternalBrowser(getContext(), request.getUrl().toString());
-                } else {
+                String host = Strings.nullToEmpty(request.getUrl().getHost());
+                if(host.contains("nga") || host.contains("178")){
                     webView.loadUrl(request.getUrl().toString());
+                } else {
+                    startExternalBrowser(getContext(), request.getUrl().toString());
                 }
                 return true;
             }


### PR DESCRIPTION
https://github.com/sunfkny/NGA-CLIENT-VER-OPEN-SOURCE/blob/2d4399c41e7d205083e4e0d5c5e4c46ce21b2a3d/nga_phone_base_3.0/src/main/java/gov/anzong/androidnga/activity/fragment/WebViewFragment.java#L86-L94
此处似乎有逻辑问题，打开包含178的链接会在外置浏览器打开
另外不应该以url来判断，改为了host判断
顺便解决了点击`APP阅读`按钮（即打开 `nga://?tid=xxxxxx`）时出现 ERR_UNKNOWN_URL_SCHEME 的问题