### PR TITLE
Teawk gradle

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -1,15 +1,11 @@
 buildscript {
     ext.kotlin_version = '1.3.72'
     repositories {
+        maven { url 'https://maven.aliyun.com/repository/google' }
+        maven { url 'https://maven.aliyun.com/repository/central' }
+        maven { url 'https://maven.aliyun.com/repository/gradle-plugin' }
         google()
         mavenCentral()
-        maven { url 'http://maven.aliyun.com/nexus/content/groups/public/' }
-        maven { url 'http://oss.sonatype.org/content/repositories/snapshots' }
-        maven {url 'https://maven.aliyun.com/repository/google'}
-        maven { url "https://www.jitpack.io" }
-        maven { url 'https://repo1.maven.org/maven2/' }
-
-        maven { url 'https://dl.bintray.com/kotlin/kotlin-eap' }
     }
     dependencies {
         classpath 'com.android.tools.build:gradle:4.2.2'
@@ -19,15 +15,12 @@ buildscript {
 
 allprojects {
     repositories {
+        maven { url 'https://maven.aliyun.com/repository/google'}
+        //TODO Remove all dependencies in jcenter
+        maven { url 'https://maven.aliyun.com/repository/public' }
+        maven { url "https://www.jitpack.io" }
         google()
         mavenCentral()
-        maven { url 'http://maven.aliyun.com/nexus/content/groups/public/' }
-        maven {url 'https://maven.aliyun.com/repository/google'}
-        maven { url "https://www.jitpack.io" }
-        maven { url 'https://repo1.maven.org/maven2/' }
-        flatDir {
-            dirs 'libs'
-        }
     }
 }
 

--- a/lib_cloud/build.gradle
+++ b/lib_cloud/build.gradle
@@ -1,4 +1,6 @@
-apply plugin: 'com.android.library'
+plugins {
+    id 'com.android.library'
+}
 
 android {
     compileSdkVersion project.compileSdkVersion
@@ -23,8 +25,6 @@ android {
 }
 
 dependencies {
-    implementation fileTree(dir: 'libs', include: ['*.jar'])
-
     testImplementation 'junit:junit:4.12'
     androidTestImplementation 'androidx.test.ext:junit:1.1.1'
     androidTestImplementation 'androidx.test.espresso:espresso-core:3.2.0'

--- a/lib_common/build.gradle
+++ b/lib_common/build.gradle
@@ -1,5 +1,7 @@
-apply plugin: 'com.android.library'
-apply plugin: 'kotlin-android'
+plugins {
+    id 'com.android.library'
+    id 'kotlin-android'
+}
 
 android {
     compileSdkVersion project.compileSdkVersion
@@ -29,8 +31,6 @@ android {
 }
 
 dependencies {
-    implementation fileTree(dir: 'libs', include: ['*.jar'])
-
     testImplementation 'junit:junit:4.12'
     androidTestImplementation 'androidx.test.ext:junit:1.1.1'
     androidTestImplementation 'androidx.test.espresso:espresso-core:3.2.0'
@@ -59,7 +59,6 @@ dependencies {
 
     // kotlin
     implementation "androidx.core:core-ktx:1.3.0"
-    implementation "org.jetbrains.kotlin:kotlin-stdlib-jdk8:$kotlin_version"
 
     //retrofit
     implementation 'com.squareup.retrofit2:retrofit:2.3.0'

--- a/lib_core/build.gradle
+++ b/lib_core/build.gradle
@@ -1,4 +1,6 @@
-apply plugin: 'com.android.library'
+plugins {
+    id 'com.android.library'
+}
 
 android {
     compileSdkVersion project.compileSdkVersion
@@ -27,11 +29,8 @@ android {
 }
 
 dependencies {
-    implementation fileTree(dir: 'libs', include: ['*.jar'])
-
     testImplementation 'junit:junit:4.12'
     androidTestImplementation 'androidx.test.ext:junit:1.1.1'
 
     compileOnly project(':lib_common')
-
 }

--- a/lib_network/build.gradle
+++ b/lib_network/build.gradle
@@ -1,6 +1,7 @@
-apply plugin: 'com.android.library'
-apply plugin: 'kotlin-android'
-apply plugin: 'kotlin-android-extensions'
+plugins {
+    id 'com.android.library'
+    id 'kotlin-android'
+}
 
 android {
     compileSdkVersion project.compileSdkVersion
@@ -29,16 +30,8 @@ android {
 }
 
 dependencies {
-    implementation fileTree(dir: 'libs', include: ['*.jar'])
-
     testImplementation 'junit:junit:4.12'
     androidTestImplementation 'androidx.test.ext:junit:1.1.1'
 
-    implementation "org.jetbrains.kotlin:kotlin-stdlib-jdk8:$kotlin_version"
-
     implementation 'com.squareup.retrofit2:retrofit:2.3.0'
-
-}
-repositories {
-    mavenCentral()
 }

--- a/nga_phone_base_3.0/build.gradle
+++ b/nga_phone_base_3.0/build.gradle
@@ -1,6 +1,5 @@
 apply plugin: 'com.android.application'
 apply plugin: 'kotlin-android'
-apply plugin: 'kotlin-android-extensions'
 
 def static getDate() {
     def date = new Date()
@@ -94,11 +93,13 @@ android {
     }
 }
 
+repositories {
+    flatDir { dirs 'libs' }
+}
+
 dependencies {
-    implementation fileTree(include: '*.jar', dir: 'libs')
     implementation(name: 'floatingactionmenu', ext: 'aar')
 
-    implementation "androidx.legacy:legacy-support-v4:1.0.0"
     implementation "com.google.android.material:material:$androidxMaterial"
     implementation "androidx.cardview:cardview:1.0.0"
 
@@ -141,12 +142,7 @@ dependencies {
 
     // kotlin
     implementation "androidx.core:core-ktx:1.3.0"
-    implementation "org.jetbrains.kotlin:kotlin-stdlib-jdk8:$kotlin_version"
 
     //noinspection KtxExtensionAvailable
     implementation "androidx.preference:preference:$preference_version"
-}
-
-repositories {
-    mavenCentral()
 }


### PR DESCRIPTION
Clean up maven repository and use maven mirror of aliyun. Since Jcenter has been shut down in 2021, I add a TODO to remove all dependencies in Jcenter.
Use the new way to declare gradle plugins.
Remove all dependencies to include local jar.
Remove kotlin-stdlib-jdk8 because the Kotlin Gradle plugin adds the stdlib automatically.
Remove KTX plugin because it has been deprecated and it isn't used in this project.
Remove legacy-support-v4 because our minSdkVersion is 25.