### PR TITLE
Remove dexOptions

### DIFF
--- a/nga_phone_base_3.0/build.gradle
+++ b/nga_phone_base_3.0/build.gradle
@@ -77,10 +77,6 @@ android {
         }
     }
 
-    dexOptions {
-        javaMaxHeapSize "2g"
-    }
-
     lintOptions {
         abortOnError false
         disable 'MissingTranslation'


### PR DESCRIPTION
There is warning in build.gradle.
It's time to remove dexOptions.
WARNING:DSL element 'dexOptions' is obsolete and should be removed.
It will be removed in version 8.0 of the Android Gradle plugin.
Using it has no effect, and the AndroidGradle plugin optimizes dexing automatically.