### PR TITLE
Remove multiDexEnabled

### DIFF
--- a/nga_phone_base_3.0/build.gradle
+++ b/nga_phone_base_3.0/build.gradle
@@ -39,7 +39,6 @@ android {
         applicationId "gov.anzong.androidnga"
         minSdkVersion project.minSdkVersion
         targetSdkVersion project.targetSdkVersion
-        multiDexEnabled true
         resConfigs "zh", "en"
 
         versionCode project.appVersionCode


### PR DESCRIPTION
According to https://developer.android.com/studio/build/multidex, multiDexEnabled is only needed if the app has a minSdk of API 20 or lower.