### PR TITLE
Remove exclude meta-inf packaging options

### DIFF
--- a/nga_phone_base_3.0/build.gradle
+++ b/nga_phone_base_3.0/build.gradle
@@ -29,12 +29,6 @@ android {
         }
     }
 
-    packagingOptions {
-        exclude 'META-INF/LICENSE.txt'
-        exclude 'META-INF/NOTICE.txt'
-        exclude 'META-INF/MANIFEST.MF'
-    }
-
     defaultConfig {
         applicationId "gov.anzong.androidnga"
         minSdkVersion project.minSdkVersion


### PR DESCRIPTION
It seems that this exclusion is a workaround in early version Android Studio. There isn't any one of those three files in the APK if those packaging options are removed.